### PR TITLE
FIX: SSMConsole policy missing arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell

### DIFF
--- a/02_aws/terraform-example/connector/iam.tf
+++ b/02_aws/terraform-example/connector/iam.tf
@@ -208,9 +208,6 @@ resource "aws_iam_role_policy" "connector_SSMConsole" {
 EOF
 }
 
-# ssh_ssm: failed to start ssm session: operation error SSM: StartSession, https response error StatusCode: 400, RequestID: 23abf47c-5be2-4833-a0b2-3cb349a12192, api error AccessDeniedException: User: 
-# arn:aws:sts::937166400989:assumed-role/border0-terraform-example-connector-role/i-0d2d9ff36efcb7715 is not authorized to perform: ssm:StartSession on resource: arn:aws:ssm:ca-central-1:937166400989:document/SSM-SessionManagerRunShell because no identity-based policy allows the ssm:StartSession action
-
 # IAM Role
 resource "aws_iam_role" "border0-connector-role" {
   name = var.prefix != "" ? "${var.prefix}-connector-role" : "Border0-example-connector-role"

--- a/02_aws/terraform-example/connector/iam.tf
+++ b/02_aws/terraform-example/connector/iam.tf
@@ -191,7 +191,7 @@ resource "aws_iam_role_policy" "connector_SSMConsole" {
     {
       "Action" : ["ssm:StartSession", "ssm:TerminateSession", "ssm:ResumeSession"],
       "Effect" : "Allow",
-      "Resource" : ["arn:aws:ec2:*:*:instance/*", "arn:aws:ecs:*:*:task/*"]
+      "Resource" : ["arn:aws:ec2:*:*:instance/*", "arn:aws:ecs:*:*:task/*", "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell"]
     },
     {
       "Action" : ["ssm:UpdateInstanceInformation"],
@@ -207,6 +207,9 @@ resource "aws_iam_role_policy" "connector_SSMConsole" {
 }
 EOF
 }
+
+# ssh_ssm: failed to start ssm session: operation error SSM: StartSession, https response error StatusCode: 400, RequestID: 23abf47c-5be2-4833-a0b2-3cb349a12192, api error AccessDeniedException: User: 
+# arn:aws:sts::937166400989:assumed-role/border0-terraform-example-connector-role/i-0d2d9ff36efcb7715 is not authorized to perform: ssm:StartSession on resource: arn:aws:ssm:ca-central-1:937166400989:document/SSM-SessionManagerRunShell because no identity-based policy allows the ssm:StartSession action
 
 # IAM Role
 resource "aws_iam_role" "border0-connector-role" {


### PR DESCRIPTION
Fixing error: ```failed to start ssm session: operation error SSM: StartSession, https response error StatusCode: 400, RequestID: 23abf47c-5be2-4833-a0b2-3cb349a12192, api error AccessDeniedException: User: arn:aws:sts::1234567890:assumed-role/border0-terraform-example-connector-role/i-0dbf9ff36efcb7715 is not authorized to perform: ssm:StartSession on resource: arn:aws:ssm:ca-central-1:1234567890:document/SSM-SessionManagerRunShell because no identity-based policy allows the ssm:StartSession action```